### PR TITLE
Picked from http://git.denx.de/?p=u-boot.git;a=summary AARCH64 (arm64…

### DIFF
--- a/mkimage/image.h
+++ b/mkimage/image.h
@@ -76,6 +76,15 @@
 #define IH_CPU_MICROBLAZE	14	/* MicroBlaze   */
 #define IH_CPU_NIOS2		15	/* Nios-II	*/
 #define IH_CPU_BLACKFIN		16	/* Blackfin	*/
+#define IH_CPU_AVR32    17   /* AVR32  */
+#define IH_CPU_ST200    18   /* STMicroelectronics ST200  */
+#define IH_CPU_SANDBOX  19   /* Sandbox architecture (test only) */
+#define IH_CPU_NDS32    20   /* ANDES Technology - NDS32  */
+#define IH_CPU_OPENRISC 21   /* OpenRISC 1000  */
+#define IH_CPU_ARM64    22   /* ARM64  */
+#define IH_CPU_ARC      23   /* Synopsys DesignWare ARC */
+#define IH_CPU_X86_64   24   /* AMD x86_64, Intel and Via */
+#define IH_CPU_XTENSA   25   /* Xtensa */
 
 /*
  * Image Types
@@ -116,14 +125,39 @@
  *	as command interpreter (=> Shell Scripts).
  */
 
-#define IH_TYPE_INVALID		0	/* Invalid Image		*/
-#define IH_TYPE_STANDALONE	1	/* Standalone Program		*/
-#define IH_TYPE_KERNEL		2	/* OS Kernel Image		*/
-#define IH_TYPE_RAMDISK		3	/* RAMDisk Image		*/
-#define IH_TYPE_MULTI		4	/* Multi-File Image		*/
-#define IH_TYPE_FIRMWARE	5	/* Firmware Image		*/
-#define IH_TYPE_SCRIPT		6	/* Script file			*/
-#define IH_TYPE_FILESYSTEM	7	/* Filesystem Image (any type)	*/
+#define IH_TYPE_INVALID		  0  /* Invalid Image		*/
+#define IH_TYPE_STANDALONE	  1  /* Standalone Program		*/
+#define IH_TYPE_KERNEL		  2  /* OS Kernel Image		*/
+#define IH_TYPE_RAMDISK		  3  /* RAMDisk Image		*/
+#define IH_TYPE_MULTI		  4  /* Multi-File Image		*/
+#define IH_TYPE_FIRMWARE	  5  /* Firmware Image		*/
+#define IH_TYPE_SCRIPT		  6  /* Script file			*/
+#define IH_TYPE_FILESYSTEM	  7  /* Filesystem Image (any type)	*/
+#define IH_TYPE_SCRIPT        8  /* Script file      */
+#define IH_TYPE_FILESYSTEM    9  /* Filesystem Image (any type)  */
+#define IH_TYPE_FLATDT        10 /* Binary Flat Device Tree Blob */
+#define IH_TYPE_KWBIMAGE      11 /* Kirkwood Boot Image    */
+#define IH_TYPE_IMXIMAGE      12 /* Freescale IMXBoot Image  */
+#define IH_TYPE_UBLIMAGE      13 /* Davinci UBL Image    */
+#define IH_TYPE_OMAPIMAGE     14 /* TI OMAP Config Header Image  */
+#define IH_TYPE_AISIMAGE      15 /* TI Davinci AIS Image   */
+/* OS Kernel Image, can run from any load address */
+#define IH_TYPE_KERNEL_NOLOAD 16
+#define IH_TYPE_PBLIMAGE      17 /* Freescale PBL Boot Image */
+#define IH_TYPE_MXSIMAGE      18 /* Freescale MXSBoot Image  */
+#define IH_TYPE_GPIMAGE       19 /* TI Keystone GPHeader Image */
+#define IH_TYPE_ATMELIMAGE    20 /* ATMEL ROM bootable Image */
+#define IH_TYPE_SOCFPGAIMAGE  21 /* Altera SOCFPGA Preloader */
+#define IH_TYPE_X86_SETUP     22 /* x86 setup.bin Image    */
+#define IH_TYPE_LPC32XXIMAGE  23 /* x86 setup.bin Image    */
+#define IH_TYPE_LOADABLE      24 /* A list of typeless images  */
+#define IH_TYPE_RKIMAGE       25 /* Rockchip Boot Image    */
+#define IH_TYPE_RKSD          26 /* Rockchip SD card   */
+#define IH_TYPE_RKSPI         27 /* Rockchip SPI image   */
+#define IH_TYPE_ZYNQIMAGE     28 /* Xilinx Zynq Boot Image */
+#define IH_TYPE_ZYNQMPIMAGE   29 /* Xilinx ZynqMP Boot Image */
+#define IH_TYPE_FPGA          30 /* FPGA Image */
+#define IH_TYPE_VYBRIDIMAGE   31 /* VYBRID .vyb Image */
 
 /*
  * Compression Types
@@ -131,6 +165,9 @@
 #define IH_COMP_NONE		0	/*  No	 Compression Used	*/
 #define IH_COMP_GZIP		1	/* gzip	 Compression Used	*/
 #define IH_COMP_BZIP2		2	/* bzip2 Compression Used	*/
+#define IH_COMP_LZMA        3   /* lzma  Compression Used */
+#define IH_COMP_LZO         4   /* lzo   Compression Used */
+#define IH_COMP_LZ4         5   /* lz4   Compression Used */
 
 #define IH_MAGIC	0x27051956	/* Image Magic Number		*/
 #define IH_NMLEN		32	/* Image Name Length		*/

--- a/mkimage/mkimage.c
+++ b/mkimage/mkimage.c
@@ -95,6 +95,14 @@ table_entry_t arch_name[] = {
     {	IH_CPU_SPARC,		"sparc",	"SPARC",	},
     {	IH_CPU_SPARC64,		"sparc64",	"SPARC 64 Bit",	},
     {	IH_CPU_BLACKFIN,	"blackfin",	"Blackfin",	},
+    {   IH_CPU_AVR32,    "avr32",  "AVR32",  },
+    {   IH_CPU_NDS32,    "nds32",  "NDS32",  },
+    {   IH_CPU_OPENRISC, "or1k",   "OpenRISC 1000",},
+    {   IH_CPU_SANDBOX,  "sandbox",  "Sandbox",  },
+    {   IH_CPU_ARM64,    "arm64",  "AArch64",  },
+    {   IH_CPU_ARC,    "arc",    "ARC",    },
+    {   IH_CPU_X86_64,   "x86_64", "AMD x86_64", },
+    {   IH_CPU_XTENSA,   "xtensa", "Xtensa", },
     {	-1,			"",		"",		},
 };
 
@@ -138,6 +146,9 @@ table_entry_t comp_name[] = {
     {	IH_COMP_NONE,	"none",		"uncompressed",		},
     {	IH_COMP_BZIP2,	"bzip2",	"bzip2 compressed",	},
     {	IH_COMP_GZIP,	"gzip",		"gzip compressed",	},
+    {   IH_COMP_LZMA,   "lzma",     "lzma compressed",  },
+    {   IH_COMP_LZO,    "lzo",      "lzo compressed",   },
+    {   IH_COMP_LZ4,    "lz4",      "lz4 compressed",   },
     {	-1,		"",		"",			},
 };
 


### PR DESCRIPTION
…) defines so mkimage can build arm64 uboot imgs.